### PR TITLE
Fix SCANmechjeb whitelist path

### DIFF
--- a/GameData/MADLAD/Whitelist.cfg
+++ b/GameData/MADLAD/Whitelist.cfg
@@ -13,7 +13,7 @@ MADLAD_WHITELIST
     MOD
     {
         ModName = SCANmechjeb
-        DependencyPath = Mechjeb2/Plugins/MechJeb2.dll
+        DependencyPath = MechJeb2/Plugins/MechJeb2.dll
     }
     MOD
     {


### PR DESCRIPTION
## Summary
- Fix the SCANmechjeb whitelist dependency path to match the MechJeb2 package directory casing.
- Leave version, packaging, and KSP compatibility metadata unchanged.

## Problem
MADLAD checks whitelist dependencies with `File.Exists`. On Linux, the current `Mechjeb2/Plugins/MechJeb2.dll` path does not match the actual `MechJeb2/Plugins/MechJeb2.dll` package path, so SCANmechjeb loader errors can be treated as expected missing-dependency errors even when MechJeb2 is installed.

## Validation
- Checked README/license/community profile, all issues, and all PRs before changing anything.
- Confirmed current MechJeb2 package `2.15.2.0` installs `MechJeb2/Plugins/MechJeb2.dll`.
- Reproduced the case-sensitive path behavior on Linux: the old whitelist path is missing while the fixed path exists.
- Ran `git diff --check`.